### PR TITLE
Add origin field to primitives

### DIFF
--- a/alpha_automl/utils.py
+++ b/alpha_automl/utils.py
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 
 COLUMN_TRANSFORMER_ID = 'sklearn.compose.ColumnTransformer'
 COLUMN_SELECTOR_ID = 'ColumnSelector'
+NATIVE_PRIMITIVE = 'native'
+ADDED_PRIMITIVE = 'added'
 RANDOM_SEED = 0
 
 


### PR DESCRIPTION
This will help to identify whether a primitive comes from Alpha-AutoML (e.g. sklearn or built-in primitive) or is added on-the-fly.