### PR TITLE
Provide options to install Alpha-AutoML

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Install Package
         run: |
-          pip install -e .[all]
+          pip install -e .[full]
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest
-          pip install git+https://github.com/cfculhane/fastText
+          pip install fasttext-wheel  # this is needed to install correctly the fasttext dependencies
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Install Package
         run: |
-          pip install -e .
+          pip install -e .[all]
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include LICENSE.txt
 include NOTICE.txt
 include README.md
 include requirements.txt
+include extra_requirements.txt
 include alpha_automl/resource/*.json
 include alpha_automl/resource/*.bnf

--- a/alpha_automl/_optional_dependency.py
+++ b/alpha_automl/_optional_dependency.py
@@ -1,10 +1,14 @@
 import importlib
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def import_optional_dependency(dependency_name):
+    dependency_module = None
     try:
         dependency_module = importlib.import_module(dependency_name)
     except ImportError:
-        raise ImportError(f'Missing optional dependency "{dependency_name}". Use pip or conda to install it.')
+        logging.warning(f'Missing optional dependency "{dependency_name}". Use pip or conda to install it.')
 
     return dependency_module

--- a/alpha_automl/wrapper_primitives/fasttext.py
+++ b/alpha_automl/wrapper_primitives/fasttext.py
@@ -3,6 +3,8 @@ import numpy as np
 from alpha_automl._optional_dependency import import_optional_dependency
 from alpha_automl.base_primitive import BasePrimitive
 
+fasttext = import_optional_dependency('fasttext')
+
 
 class FastTextEmbedder(BasePrimitive):
     """
@@ -19,9 +21,7 @@ class FastTextEmbedder(BasePrimitive):
                               fasttext.util.download_model('en', if_exists='ignore')  # English
                               fasttext_model_path = '<path_to_model>/cc.en.300.bin' 
     """
-    # Load dependency
-    fasttext_lib = import_optional_dependency('fasttext')
-    
+
     def __init__(self, fasttext_model_path):
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.fasttext_model_path = fasttext_model_path
@@ -31,7 +31,7 @@ class FastTextEmbedder(BasePrimitive):
 
     def transform(self, texts):
         # Load fasttext model
-        fasttext_model = fasttext_lib.load_model(self.fasttext_model_path)
+        fasttext_model = fasttext.load_model(self.fasttext_model_path)
         text_list = texts.tolist()
         
         embeddings = [fasttext_model.get_sentence_vector(str(text).strip()) for text in text_list]

--- a/alpha_automl/wrapper_primitives/fasttext.py
+++ b/alpha_automl/wrapper_primitives/fasttext.py
@@ -19,6 +19,8 @@ class FastTextEmbedder(BasePrimitive):
                               fasttext.util.download_model('en', if_exists='ignore')  # English
                               fasttext_model_path = '<path_to_model>/cc.en.300.bin' 
     """
+    # Load dependency
+    fasttext_lib = import_optional_dependency('fasttext')
     
     def __init__(self, fasttext_model_path):
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -28,12 +30,8 @@ class FastTextEmbedder(BasePrimitive):
         return self
 
     def transform(self, texts):
-        
-        # Load dependencies
-        fasttext = import_optional_dependency('fasttext')
-        
         # Load fasttext model
-        fasttext_model = fasttext.load_model(self.fasttext_model_path)
+        fasttext_model = fasttext_lib.load_model(self.fasttext_model_path)
         text_list = texts.tolist()
         
         embeddings = [fasttext_model.get_sentence_vector(str(text).strip()) for text in text_list]

--- a/alpha_automl/wrapper_primitives/huggingface.py
+++ b/alpha_automl/wrapper_primitives/huggingface.py
@@ -1,12 +1,11 @@
+import torch
 import numpy as np
 from alpha_automl._optional_dependency import import_optional_dependency
 from alpha_automl.base_primitive import BasePrimitive
-import torch
+transformers = import_optional_dependency('transformers')
 
 
 class HuggingfaceEmbedder(BasePrimitive):
-    # Load dependency
-    transformers_lib = import_optional_dependency('transformers')
 
     def __init__(self, name, last_four_model_layers=False):
         self.name = name
@@ -29,8 +28,8 @@ class HuggingfaceEmbedder(BasePrimitive):
         batch_embeddings = []
 
         # Loading tokenizer and model
-        tokenizer = transformers_lib.AutoTokenizer.from_pretrained(self.name)
-        model = transformers_lib.AutoModel.from_pretrained(self.name, output_hidden_states=True)
+        tokenizer = transformers.AutoTokenizer.from_pretrained(self.name)
+        model = transformers.AutoModel.from_pretrained(self.name, output_hidden_states=True)
 
         for start in range(0, total_length, batch_size):
             if start == (steps * batch_size):

--- a/alpha_automl/wrapper_primitives/huggingface.py
+++ b/alpha_automl/wrapper_primitives/huggingface.py
@@ -1,10 +1,12 @@
 import numpy as np
-from transformers import AutoTokenizer, AutoModel
+from alpha_automl._optional_dependency import import_optional_dependency
 from alpha_automl.base_primitive import BasePrimitive
 import torch
 
 
 class HuggingfaceEmbedder(BasePrimitive):
+    # Load dependency
+    transformers_lib = import_optional_dependency('transformers')
 
     def __init__(self, name, last_four_model_layers=False):
         self.name = name
@@ -27,8 +29,8 @@ class HuggingfaceEmbedder(BasePrimitive):
         batch_embeddings = []
 
         # Loading tokenizer and model
-        tokenizer = AutoTokenizer.from_pretrained(self.name)
-        model = AutoModel.from_pretrained(self.name, output_hidden_states=True)
+        tokenizer = transformers_lib.AutoTokenizer.from_pretrained(self.name)
+        model = transformers_lib.AutoModel.from_pretrained(self.name, output_hidden_states=True)
 
         for start in range(0, total_length, batch_size):
             if start == (steps * batch_size):

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,14 +1,37 @@
 Installation
 ============
 
-This package works with Python 3.6+ in Linux, Mac and Windows. To install, run this command:
+This package works with Python 3.6+ in Linux, Mac and Windows. There are different options to install it.
+
+
+- To install the default version of Alpha-AutoML (support for classification, regression and semi-supervised tasks), run:
 
 ::
 
    $ pip install alpha-automl
 
 
-To install the latest development version:
+- To support time-series tasks, install:
+
+::
+
+   $ pip install alpha-automl[timeseries]
+
+
+- To install NLP primitives, run:
+
+::
+
+   $ pip install alpha-automl[nlp]
+
+
+- To support all the ML tasks, install:
+
+::
+
+   $ pip install alpha-automl[all]
+
+- To install the latest development version:
 
 ::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -29,7 +29,7 @@ This package works with Python 3.6+ in Linux, Mac and Windows. There are differe
 
 ::
 
-   $ pip install alpha-automl[all]
+   $ pip install alpha-automl[full]
 
 - To install the latest development version:
 

--- a/extra_requirements.txt
+++ b/extra_requirements.txt
@@ -1,0 +1,8 @@
+pandas==1.5.3:              timeseries
+gluonts==0.12.7:            timeseries
+numpy==1.23.5:              timeseries
+neuralforecast==1.5.0:      timeseries
+mxnet==1.9.1:               timeseries
+pmdarima==2.0.3:            timeseries
+fasttext:                   nlp
+transformers:               nlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,15 +3,8 @@ scikit-learn
 torch>=1.7
 nltk
 pipelineprofiler
-pandas==1.5.3
+pandas
 datamart_profiler
 feature_engine
 xgboost
 lightgbm
-gluonts==0.12.7
-numpy==1.23.5
-neuralforecast==1.5.0
-mxnet==1.9.1
-pmdarima==2.0.3
-fasttext
-transformers

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 import os
+import re
 import setuptools
+from collections import defaultdict
 
 package_name = 'alpha-automl'
 package_dir = 'alpha_automl'
@@ -21,26 +23,52 @@ def read_version():
     raise KeyError('Version not found in {0}'.format(module_path))
 
 
+def get_requires():
+    with open('requirements.txt') as fp:
+        dependencies = [line for line in fp if line and not line.startswith('#')]
+
+        return dependencies
+
+
+def get_extra_requires():
+    with open('extra_requirements.txt') as fp:
+        extra_dependencies = defaultdict(set)
+        for k in fp:
+            if k.strip() and not k.startswith('#'):
+                tags = set()
+                if ':' in k:
+                    k, v = k.split(':')
+                    tags.update(vv.strip() for vv in v.split(','))
+                tags.add(re.split('[<=>]', k)[0])
+                for t in tags:
+                    extra_dependencies[t].add(k)
+
+        # add tag `all` at the end
+        extra_dependencies['all'] = set(vv for v in extra_dependencies.values() for vv in v)
+
+    return extra_dependencies
+
+
 long_description = read_readme()
 version = read_version()
-
-with open('requirements.txt') as fp:
-    req = [line for line in fp if line and not line.startswith('#')]
+requires = get_requires()
+extra_requires = get_extra_requires()
 
 setuptools.setup(
     name=package_name,
     version=version,
     packages=setuptools.find_packages(),
-    install_requires=req,
+    install_requires=requires,
+    extras_require=extra_requires,
     description="Alpha-AutoML: NYU's AutoML System",
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/VIDA-NYU/alpha-automl',
     include_package_data=True,
-    author='Roque Lopez, Remi Rampin',
-    author_email='rlopez@nyu.edu, remi.rampin@nyu.edu',
-    maintainer='Roque Lopez, Remi Rampin',
-    maintainer_email='rlopez@nyu.edu, remi.rampin@nyu.edu',
+    author='Roque Lopez, Eden Wu, Remi Rampin',
+    author_email='rlopez@nyu.edu, yfw215@nyu.edu, remi.rampin@nyu.edu',
+    maintainer='Roque Lopez, Eden Wu, Remi Rampin',
+    maintainer_email='rlopez@nyu.edu, yfw215@nyu.edu, remi.rampin@nyu.edu',
     keywords=['datadrivendiscovery', 'automl', 'nyu'],
     license='Apache-2.0',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ def get_extra_requires():
                 for t in tags:
                     extra_dependencies[t].add(k)
 
-        # add tag `all` at the end
-        extra_dependencies['all'] = set(vv for v in extra_dependencies.values() for vv in v)
+        # add tag `full` at the end
+        extra_dependencies['full'] = set(vv for v in extra_dependencies.values() for vv in v)
 
     return extra_dependencies
 
@@ -66,9 +66,9 @@ setuptools.setup(
     url='https://github.com/VIDA-NYU/alpha-automl',
     include_package_data=True,
     author='Roque Lopez, Eden Wu, Remi Rampin',
-    author_email='rlopez@nyu.edu, yfw215@nyu.edu, remi.rampin@nyu.edu',
+    author_email='rlopez@nyu.edu, eden.wu@nyu.edu, remi.rampin@nyu.edu',
     maintainer='Roque Lopez, Eden Wu, Remi Rampin',
-    maintainer_email='rlopez@nyu.edu, yfw215@nyu.edu, remi.rampin@nyu.edu',
+    maintainer_email='rlopez@nyu.edu, eden.wu@nyu.edu, remi.rampin@nyu.edu',
     keywords=['datadrivendiscovery', 'automl', 'nyu'],
     license='Apache-2.0',
     classifiers=[


### PR DESCRIPTION
It would allow users to install Alpha-AutoML according to their needs, e.g. some users could want to use  Alpha-AutoML for classification tasks and not for time-series classes. It will also allow installing only the necessary dependencies.

`pip install alpha-automl` installs the default support (regression, classification, and semi-supervised classification).
`pip install alpha-automl[timeseries]` installs the default support + time-series
`pip install alpha-automl[nlp]` installs the default support + sophisticated nlp primitives (e.g. huggingface)
`pip install alpha-automl[full]` installs everything