### PR TITLE
Change CI to use the version names in Docker images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,38 +18,74 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[a-zA-Z0-9]+'
 
 jobs:
-  build:
+  build-images:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Login to GitHub Container Registry
+      
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Build and push JupyterHub image
+      
+      # Creates metadata and tag names for the images named like alpha-automl:{version}-jupyterhub
+      - name: Extract Docker metadata for [{version}-jupyterhub] image
+        id: meta_full_jupyterhub
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/vida-nyu/alpha-automl
+          tags: |
+            # tags that named after release versions
+            type=match,pattern=[0-9]+\.[0-9]+\.[0-9]+.*
+            # all branches (that pass the 'on: push' trigger filter)
+            type=ref,enable=true,event=branch
+            # create latest only for devel branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'devel') }}
+          flavor: |
+            latest=false
+            suffix=-jupyterhub
+      
+      # Creates metadata and tag names for the images named like alpha-automl:{version}
+      - name: Extract Docker metadata for [{version}] image
+        id: meta_full
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/vida-nyu/alpha-automl
+          tags: |
+            # tags that named after release versions
+            type=match,pattern=[0-9]+\.[0-9]+\.[0-9]+.*
+            # all branches (that pass the 'on: push' trigger filter)
+            type=ref,enable=true,event=branch
+            # create latest only for devel branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'devel') }}
+          flavor: |
+            latest=false
+      
+      # Builds and pushes images named like alpha-automl:{version}-jupyterhub
+      - name: Build and push JupyterHub image [ghcr.io/vida-nyu/alpha-automl:{version}-jupyterhub]
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile
           target: alpha-automl-jupyterhub
-          push: true
-          tags: ghcr.io/vida-nyu/alpha-automl:latest-jupyterhub
-      -
-        name: Build and push Jupyter Notebook image
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta_full_jupyterhub.outputs.tags }}
+          labels: ${{ steps.meta_full_jupyterhub.outputs.labels }}
+      
+      # Builds and pushes images named like alpha-automl:{version}
+      - name: Build and push Jupyter Notebook image [ghcr.io/vida-nyu/alpha-automl:{version}]
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile
           target: alpha-automl
-          push: true
-          tags: ghcr.io/vida-nyu/alpha-automl:latest
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta_full.outputs.tags }}
+          labels: ${{ steps.meta_full.outputs.labels }}
 


### PR DESCRIPTION
This, along with PR #49, completes issue #50.

Images are automatically built for any tag or branch with version names, e.g., `0.3.0` or `0.3.0-rc1`. In addition, all commits pushed to the `devel` branch with trigger an image build that will be published using version `latest`.

In both cases, two images are build:
- `alpha-automl:{version}`, which is a Jupyter notebook server that includes the examples from the repository.
- `alpha-automl:{version}-jupyterhub`, which can be used as part of a custom JupyterHub deployment as documented in [https://github.com/VIDA-NYU/alpha-automl/blob/devel/kubernetes/README.md](https://github.com/VIDA-NYU/alpha-automl/blob/devel/kubernetes/README.md).

As an example branch `0.3.0-dockerbuild` creates the images:
- `ghcr.io/vida-nyu/alpha-automl:0.3.0-dockerbuild`
- `ghcr.io/vida-nyu/alpha-automl:0.3.0-dockerbuild-jupyterhub`
