### PR TITLE
add cull for unused/inactive server

### DIFF
--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -1,17 +1,22 @@
 hub:
   config:
     Authenticator:
-      admin_users:
+      allowed_users:
         - yfw215
         - demouser
+      admin_users:
+        - yfw215
     DummyAuthenticator:
       password: 'alpha_automl'
     JupyterHub:
       admin_access: true
       authenticator_class: tmpauthenticator.TmpAuthenticator
+    TmpAuthenticator:
+      auto_login: false
   shutdownOnLogout: true
   networkPolicy:
     enabled: false
+  concurrentSpawnLimit: 32
 proxy:
   service:
     type: ClusterIP
@@ -31,6 +36,18 @@ singleuser:
   image:
     name: ghcr.io/vida-nyu/alpha-automl
     tag: latest-jupyterhub
+  extraFiles:
+    jupyter_notebook_config.json:
+      mountPath: /etc/jupyter/jupyter_notebook_config.json
+      data:
+        TerminalManager:
+          cull_inactive_timeout: 1200
+          cull_interval: 120
+        MappingKernelManager:
+          cull_idle_timeout: 1200
+          cull_interval: 120
+          cull_connected: true
+          cull_busy: false
 scheduling:
   userScheduler:
     enabled: false
@@ -46,3 +63,7 @@ ingress:
   tls:
     - hosts:
         - alpha-automl.hsrn.nyu.edu
+cull:
+  enabled: true
+  timeout: 1200 
+  every: 120

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -41,10 +41,10 @@ singleuser:
       mountPath: /etc/jupyter/jupyter_notebook_config.json
       data:
         TerminalManager:
-          cull_inactive_timeout: 1200
+          cull_inactive_timeout: 3600
           cull_interval: 120
         MappingKernelManager:
-          cull_idle_timeout: 1200
+          cull_idle_timeout: 3600
           cull_interval: 120
           cull_connected: true
           cull_busy: false
@@ -65,5 +65,5 @@ ingress:
         - alpha-automl.hsrn.nyu.edu
 cull:
   enabled: true
-  timeout: 1200 
+  timeout: 3600 
   every: 120


### PR DESCRIPTION
Okay, thank you! 
I will do that.

Roque Lopez <[rlopez@nyu.edu](mailto:rlopez@nyu.edu)> 于2023年11月29日周三 15:02写道：
Hi Eden,

As far as I know, members of the D3M project are not using these containers at that rate. My impression is that these are kind of zombie containers, I mean, users started them, but they were not killed properly. Feel free to get rid of them and please, update the configs to limit the container lifetime to 24 hours. Thanks!

Regards,


On Wed, Nov 29, 2023 at 2:25 PM Eden Wu <[yfw215@nyu.edu](mailto:yfw215@nyu.edu)> wrote:

Hi Roque,

Rémi emailed me about this high volume container usage issue on our k8s cluster. Do you have an idea of what is this task for?
<Screenshot from 2023-11-29 14-21-51.png>

Eden

---------- Forwarded message ---------
发件人： Rémi Rampin <[remi.rampin@nyu.edu](mailto:remi.rampin@nyu.edu)>
Date: 2023年11月29日周三 14:10
Subject: HSRN Kubernetes: High number of volumes in 'alphad3m'
To: Eden Wu <[yfw215@nyu.edu](mailto:yfw215@nyu.edu)>
Cc: <[hsrn-staff@nyu.edu](mailto:hsrn-staff@nyu.edu)>


Hi Eden,

There is a high number of PersistentVolumeClaims accumulating in your namespace 'alphad3m'. They follow the format 'claim-<random-looking-id>'. As I'm writing this email, there are 48 volumes total.

Are all those volumes required? Could there be some configuration issue causing those volumes to accumulate?

Thanks
-- 
Rémi Rampin
Senior Research Network Engineer
High Speed Research Network
NYU Research and Instructional Technology


-- 
Yifan (Eden) Wu
Master of Computer Science
New York University

 +1 6467061025 |  [eden.wu@nyu.edu](mailto:eden.wu@nyu.edu)

   



-- 
Roque Lopez


-- 
Yifan (Eden) Wu
Master of Computer Science
New York University

 +1 6467061025 |  [eden.wu@nyu.edu](mailto:eden.wu@nyu.edu)